### PR TITLE
Watch tests with --watch or -w

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ module.exports = {
           'Run tests faster by relaying the output from the /tests route to stdout',
         availableOptions: [
           { name: 'filter', type: String, default: false, aliases: ['f'] },
+          { name: 'watch', type: Boolean, default: false, aliases: ['w'] },
         ],
 
-        async run({ filter }) {
+        async run({ filter, watch }) {
           this.ui.writeLine("Ember Play starting...");
           const env = this.project.config(this.environment);
           const framework = determineTestFramework(this.project);
@@ -38,6 +39,7 @@ module.exports = {
             framework,
             host: host + env.rootURL,
             ui: this.ui,
+            watch,
           });
 
           process.on('SIGINT', () => {

--- a/index.js
+++ b/index.js
@@ -42,11 +42,6 @@ module.exports = {
             watch,
           });
 
-          process.on('SIGINT', () => {
-            this.ui.writeLine('');
-            this.ui.writeWarnLine('SIGINT, Exiting early');
-          });
-
           await play.run(filter);
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-play",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/play/index.js
+++ b/play/index.js
@@ -70,6 +70,11 @@ class Play {
           this.firstRun = false;
         }
       });
+    } else {
+      process.on('SIGINT', () => {
+        this.ui.writeLine('');
+        this.ui.writeWarnLine('SIGINT, Exiting early');
+      });
     }
 
     await page.goto(url);

--- a/play/reporter.js
+++ b/play/reporter.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+const { resetLine } = require('./utils');
 
 class Spinner {
   constructor(ui, colorfn) {
@@ -150,13 +151,6 @@ function humanDuration(duration) {
   if (m) return `${m}m ${fs}s ${fms}ms`;
   else if (s) return `${fs}s ${fms}ms`;
   return `${ms}ms`;
-}
-
-function resetLine() {
-  if (process.stdout.isTTY) {
-    process.stdout.clearLine();
-    process.stdout.cursorTo(0);
-  }
 }
 
 module.exports = Reporter;

--- a/play/utils.js
+++ b/play/utils.js
@@ -1,0 +1,8 @@
+module.exports = {
+  resetLine() {
+    if (process.stdout.isTTY) {
+      process.stdout.clearLine();
+      process.stdout.cursorTo(0);
+    }
+  }
+}


### PR DESCRIPTION
By keeping the playwright script running instead of exiting when the test run completes, tests are watched automatically by virtue of the common reporter interface hooks.

Using the `page.on('framenavigated')` event allows for some improved DX around what's going on and what do about it.