### PR TITLE
Open tests in a browser with -b or --browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A build-free test runner for Ember apps.
 1. Runs tests from your already running Ember app
 2. Filter tests using the familiar `-f` or `--filter` flag
 3. Watch tests with the `-w` or `--watch` flag
-4. (Soon!) Quickly move to a browser with the `-b` or `--browswer` flag
+4. Quickly move to a browser with the `-b` or `--browswer` flag
 5. (Soon!) Mocha support, with automatic detection
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A build-free test runner for Ember apps.
 
 1. Runs tests from your already running Ember app
 2. Filter tests using the familiar `-f` or `--filter` flag
-3. (Soon!) Watch tests with the `-f` or `--watch` flag
+3. Watch tests with the `-w` or `--watch` flag
 4. (Soon!) Quickly move to a browser with the `-b` or `--browswer` flag
 5. (Soon!) Mocha support, with automatic detection
 

--- a/index.js
+++ b/index.js
@@ -18,9 +18,10 @@ module.exports = {
         availableOptions: [
           { name: 'filter', type: String, default: false, aliases: ['f'] },
           { name: 'watch', type: Boolean, default: false, aliases: ['w'] },
+          { name: 'browser', type: Boolean, default: false, aliases: ['b'] },
         ],
 
-        async run({ filter, watch }) {
+        async run({ filter, watch, browser }) {
           this.ui.writeLine("Ember Play starting...");
           const env = this.project.config(this.environment);
           const framework = determineTestFramework(this.project);
@@ -43,7 +44,11 @@ module.exports = {
             watch,
           });
 
-          await play.run();
+          if (browser) {
+            await play.open();
+          } else {
+            await play.run();
+          }
         },
       },
     };

--- a/index.js
+++ b/index.js
@@ -39,10 +39,11 @@ module.exports = {
             framework,
             host: host + env.rootURL,
             ui: this.ui,
+            filter,
             watch,
           });
 
-          await play.run(filter);
+          await play.run();
         },
       },
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6568,6 +6568,11 @@
         }
       }
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -12229,8 +12234,7 @@
     "is-docker": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-      "dev": true
+      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -14070,6 +14074,26 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "open": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.6.tgz",
+      "integrity": "sha512-vDOC0KwGabMPFtIpCO2QOnQeOz0N2rEkbuCuxICwLMUCrpv+A7NHrrzJ2dQReJmVluHhO4pYRh/Pn6s8t7Op6Q==",
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        }
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-cli-babel": "^7.23.1",
     "ember-cli-htmlbars": "^5.3.2",
     "events": "^3.3.0",
+    "open": "^8.0.6",
     "playwright": "^1.10.0",
     "query-string": "^7.0.0",
     "resolve-package-path": "^3.1.0"

--- a/play/index.js
+++ b/play/index.js
@@ -19,18 +19,19 @@ class CoPromise {
 class Play {
   firstRun = true;
 
-  constructor({ host, framework, ui, watch }) {
+  constructor({ host, framework, ui, filter, watch }) {
     this.host = host;
     this.framework = framework;
     this.ui = ui;
     this.watch = watch;
+    this.filter = filter;
   }
 
-  async run(filter) {
+  async run() {
     const ui = this.ui;
     const params = { __emberplay: true };
-    if (filter) {
-      params.filter = filter;
+    if (this.filter) {
+      params.filter = this.filter;
     }
     const url = `${appendPath(this.host, 'tests')}?${queryString.stringify(params)}`;
 


### PR DESCRIPTION
This uses the popular [open]() module to add cross-platform support for opening URLs in browsers. 

This is functionally no different than going to the `/tests` page in a browser on your own, but it's convenient to be able to quickly move to a browser from the CLI when needing to dig into a test.